### PR TITLE
Adds an optional price display to the card hover.

### DIFF
--- a/src/card-widget.ts
+++ b/src/card-widget.ts
@@ -11,14 +11,84 @@ export const linkSites: Record<LinkSite, (cache: ScryfallCard) => string> = {
 	cardmarket: (cache) => cache.purchase_uris.cardmarket,
 };
 
-export function createImg(id: string, width: number) {
+export function createCardImg(id: string, width: number) {
 	const img = document.createElement("img");
 	img.className = "scryfall_card";
 	img.width = width;
 	img.id = id;
-	img.style.opacity = "0";
-	img.toggleVisibility(false);
 	return img;
+}
+
+export function createHover(id: string, width: number, showPrices: boolean) {
+	const span = document.createElement('span');
+	span.className = 'scryfall_hover';
+	span.width = width;
+	span.id = id;
+	span.style.opacity = '0';
+	span.toggleVisibility(false);
+
+	if (showPrices) {
+		span.cardPrice = document.createElement('span');
+		span.appendChild(span.cardPrice);
+		span.cardPrice.className = 'scryfall_price';
+
+		span.priceBreak = document.createElement("br");
+		span.appendChild(span.priceBreak);
+	}
+
+	const imgFront = createCardImg(`${this.id}-front`, width);
+	span.appendChild(imgFront);
+	span.cardFront = imgFront;
+
+	const imgBack = createCardImg(`${this.id}-back`, width);
+	span.cardBack = imgBack;
+	span.appendChild(imgBack);
+
+	return span;
+}
+
+export function createPriceTripletString(symbol: string, priceNormal: number, priceFoil: number, priceEtched: number) {
+	if (!priceNormal && !priceFoil && !priceEtched) {
+		return '';
+	}
+
+	let triplet = [];
+
+	if (priceNormal) {
+		triplet.push(`${symbol}${priceNormal}`);
+	}
+
+	if (priceFoil) {
+		triplet.push(`${symbol}${priceFoil}[F]`);
+	}
+
+	if (priceEtched) {
+		triplet.push(`${symbol}${priceEtched}[E]`);
+	}
+
+	return triplet.join('/');
+}
+
+export function createPriceString(prices, showUsd: boolean, showEur: boolean, showTix: boolean) {
+	if (!prices) {
+		return '(no prices found)';
+	}
+
+	let priceStrings = [];
+
+	if (showUsd) {
+		priceStrings.push(createPriceTripletString('$', prices.usd, prices.usd_foil, prices.usd_etched));
+	}
+
+	if (showEur) {
+		priceStrings.push(createPriceTripletString('€', prices.eur, prices.eur_foil, prices.eur_etched));
+	}
+
+	if (showTix && prices.tix) {
+		priceStrings.push(`${prices.tix} TIX`);
+	}
+
+	return priceStrings.filter(s => s != '').join(', ');
 }
 
 export class CardWidget extends WidgetType {
@@ -32,13 +102,16 @@ export class CardWidget extends WidgetType {
 
 	toDOM(view: EditorView): HTMLElement {
 		let width = 448 * this.settings.imageSize;
-		const img = createImg(`${this.id}-1`, width);
-		const img2 = createImg(`${this.id}-2`, width);
+		const hover = createHover(`${this.id}-hover`, width, this.settings.showPrices);
+		const offsetLeft = 15;
+		const offsetTop = 40;
 
 		getScryfallCard(this.name).then((card) => {
 			if (card == null) {
 				return;
 			}
+
+			let widthDivider = 1;
 
 			const images = [];
 			if (card.image_uris) {
@@ -46,34 +119,41 @@ export class CardWidget extends WidgetType {
 			} else if (card.card_faces) {
 				images.push(card.card_faces[0].image_uris.normal);
 				images.push(card.card_faces[1].image_uris.normal);
+				widthDivider = 2;
 			}
 
-			img.src = images[0] ?? "";
-			img2.src = images[1] ?? "";
+			hover.cardFront.src = images[0] ?? "";
+			hover.cardBack.src = images[1] ?? "";
+
+			if (this.settings.showPrices && card.prices) {
+				const priceText = createPriceString(
+					card.prices,
+					this.settings.showPricesUsd,
+					this.settings.showPricesEur,
+					this.settings.showPricesTix
+				);
+
+				if (priceText) {
+					hover.cardPrice.innerText = priceText;
+				} else {
+					hover.cardPrice.style.display = 'none';
+					hover.priceBreak.style.display = 'none';
+				}
+			}
 
 			const onMouseMove = (e: MouseEvent) => {
-				width = 448 * this.settings.imageSize;
+				width = (448 * this.settings.imageSize) / widthDivider;
 
-				if (img.width != width) {
-					img.width = width;
-				}
-
-				if (img2.width != width) {
-					img2.width = width;
+				if (hover.width != width) {
+					hover.width = width;
 				}
 
 				const rect = view.dom.getBoundingClientRect();
-				img.style.left = e.clientX - rect.left + 10 + "px";
-				img.style.top = e.clientY - rect.top + 40 + "px";
-				img2.style.left = e.clientX - rect.left + 10 + width + "px";
-				img2.style.top = e.clientY - rect.top + 40 + "px";
+				hover.style.left = e.clientX - rect.left + offsetLeft + "px";
+				hover.style.top = e.clientY - rect.top + offsetTop + "px";
 
-				if (img.style.opacity != "100%") {
-					img.style.opacity = "100%";
-				}
-
-				if (img2.style.opacity != "100%") {
-					img2.style.opacity = "100%";
+				if (hover.style.opacity != "100%") {
+					hover.style.opacity = "100%";
 				}
 
 				const element = document.getElementById(`${this.id}-a`);
@@ -95,10 +175,6 @@ export class CardWidget extends WidgetType {
 				view.dom.removeEventListener("mousemove", onMouseMove);
 		});
 
-		const span = document.createElement("span");
-		span.appendChild(img);
-		span.appendChild(img2);
-
-		return span;
+		return hover;
 	}
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,6 +19,10 @@ export class MTGCardLinksPlugin extends Plugin {
 		const defaultSettings: MTGCardLinksSettings = {
 			linkSite: "scryfall",
 			imageSize: 0.5,
+			showPrices: true,
+			showPricesUsd: true,
+			showPricesEur: true,
+			showPricesTix: true,
 		};
 
 		this.settings = Object.assign(defaultSettings, await this.loadData());

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export type LinkSite =
 export interface MTGCardLinksSettings {
 	linkSite: LinkSite;
 	imageSize: number;
+	showPrices: boolean;
 }
 
 export class MTGCardLinksSettingsTab extends PluginSettingTab {
@@ -63,5 +64,65 @@ export class MTGCardLinksSettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					});
 			});
+
+		new Setting(containerEl)
+			.setHeading()
+			.setName("Show Prices")
+			.setDesc(
+				"Show card prices when hovering over a card link."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.showPrices)
+					.onChange(async (value) => {
+						this.plugin.settings.showPrices = value;
+						await this.plugin.saveSettings();
+						this.display();
+					});
+			});
+
+		if (this.plugin.settings.showPrices) {
+			new Setting(containerEl)
+				.setName("USD")
+				.setDesc(
+					"Show prices in U.S. Dollars"
+				)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(this.plugin.settings.showPricesUsd)
+						.onChange(async (value) => {
+							this.plugin.settings.showPricesUsd = value;
+							await this.plugin.saveSettings();
+						});
+				});
+
+			new Setting(containerEl)
+				.setName("EUR")
+				.setDesc(
+					"Show prices in Euros"
+				)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(this.plugin.settings.showPricesEur)
+						.onChange(async (value) => {
+							this.plugin.settings.showPricesEur = value;
+							await this.plugin.saveSettings();
+						});
+				});
+
+			new Setting(containerEl)
+				.setName("TIX")
+				.setDesc(
+					"Show prices in Magic the Gathering Online Tickets"
+				)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(this.plugin.settings.showPricesTix)
+						.onChange(async (value) => {
+							this.plugin.settings.showPricesTix = value;
+							await this.plugin.saveSettings();
+						});
+				});
+		}
 	}
 }

--- a/src/view-plugin.ts
+++ b/src/view-plugin.ts
@@ -82,8 +82,8 @@ export class CardViewPluginValue implements PluginValue {
 								tagName: "a",
 								attributes: {
 									id: `${id}-a`,
-									onmouseover: `document.getElementById("${id}-1")?.toggleVisibility(true); document.getElementById("${id}-2")?.toggleVisibility(true)`,
-									onmouseout: `document.getElementById("${id}-1")?.toggleVisibility(false); document.getElementById("${id}-2")?.toggleVisibility(false)`,
+									onmouseover: `document.getElementById("${id}-hover")?.toggleVisibility(true)`,
+									onmouseout: `document.getElementById("${id}-hover")?.toggleVisibility(false)`,
 								},
 							})
 						);

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,18 @@ If your plugin does not need CSS, delete this file.
 */
 .scryfall_card {
   border-radius: 4.75%;
+}
+
+.scryfall_hover {
   position:fixed;
   z-index: 99;
+}
+
+.scryfall_price {
+  background-color: #000000;
+  color: #dfdfdf;
+  padding: 3px;
+  margin-bottom: 4px;
+  border-radius: 6px;
+  font-weight: bold;
 }


### PR DESCRIPTION
This PR adds an optional price display to the hover elements shown. When enabled, the price in any combination of USD, EUR, and TIX is displayed in a single line above the card image.

When used with the changes from #2, this can provide a quick and easy way to track prices for individual, specific cards.